### PR TITLE
fix for critical bug in `verifyRekeyToAbstractedAccount`& other QOL changes

### DIFF
--- a/contracts/abstracted_account.algo.ts
+++ b/contracts/abstracted_account.algo.ts
@@ -44,11 +44,11 @@ export class AbstractedAccount extends Contract {
   private verifyRekeyToAbstractedAccount(): void {
     let rekeyedBack = false;
 
-    for (let i = this.txn.groupIndex; i < this.txnGroup.length; i += 1) {
+    for (let i = (this.txn.groupIndex + 1); i < this.txnGroup.length; i += 1) {
       const txn = this.txnGroup[i];
 
       // The transaction is an explicit rekey back
-      if (txn.sender === this.controlledAddress.value && txn.rekeyTo === this.controlledAddress.value) {
+      if (txn.sender === this.controlledAddress.value && txn.rekeyTo === this.app.address) {
         rekeyedBack = true;
         break;
       }
@@ -57,6 +57,7 @@ export class AbstractedAccount extends Contract {
       if (
         txn.typeEnum === TransactionType.ApplicationCall &&
         txn.applicationID === this.app &&
+        txn.onCompletion === OnCompletion.NoOp &&
         txn.numAppArgs === 1 &&
         txn.applicationArgs[0] === method('arc58_verifyAuthAddr()void')
       ) {


### PR DESCRIPTION
This PR fixes a critical bug in the `verifyRekeyToAbstractedAccount` subroutine where in a situation where the `controlledAccount` is not the arc58 contract it would ensure the account was rekeyed back to itself instead of back to the arc58 contract.

Added a check that the onComplete action is a NoOp for the `arc58_verifyAuthAddr` method of ensuring the account gets back control. We don't currently allow optins to the contract but if that were ever to change this part of the contract could have been exploited using an onComplete of `CloseOut` to pass the check without calling the method. This has been tested and is a vulnerability in the contract if it were ever to be changed to support app optins.

Thank you to D13 for catching both of those.

The last change is a small QOL update, theres no need to include the current transaction in our iteration over the transaction group so we start our index just after to avoid the extra loop.

